### PR TITLE
Add impl of PersonaData with IdentifiedEntry and Name only

### DIFF
--- a/profile/src/v100/entity/mod.rs
+++ b/profile/src/v100/entity/mod.rs
@@ -10,3 +10,4 @@ pub use account::*;
 pub use display_name::*;
 pub use entity_flag::*;
 pub use entity_flags::*;
+pub use persona::*;

--- a/profile/src/v100/entity/persona/mod.rs
+++ b/profile/src/v100/entity/persona/mod.rs
@@ -1,2 +1,3 @@
 mod persona;
+mod persona_data;
 pub use persona::*;

--- a/profile/src/v100/entity/persona/mod.rs
+++ b/profile/src/v100/entity/persona/mod.rs
@@ -1,3 +1,5 @@
 mod persona;
 mod persona_data;
+
 pub use persona::*;
+pub use persona_data::*;

--- a/profile/src/v100/entity/persona/persona.rs
+++ b/profile/src/v100/entity/persona/persona.rs
@@ -55,7 +55,8 @@ impl Persona {
         let persona_data = persona_data.map_or(
             PersonaData::new(IdentifiedEntry::new(
                 Uuid::nil(),
-                Name::new(Variant::Western, "Wayne", "Bruce", "Batman"),
+                Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+                    .expect("Name counstruction should not fail"),
             )),
             |p| p,
         );
@@ -76,7 +77,8 @@ impl Persona {
     fn placeholder_at_index_name_network(
         network_id: NetworkID,
         index: HDPathValue,
-        name: &str,
+        display_name: &str,
+        name: Name,
     ) -> Self {
         let mwp = MnemonicWithPassphrase::placeholder();
         let bdfs = DeviceFactorSource::babylon(
@@ -91,29 +93,41 @@ impl Persona {
 
         Self::new(
             persona_creating_factor_instance,
-            DisplayName::new(name).unwrap(),
-            None,
+            DisplayName::new(display_name).unwrap(),
+            Some(PersonaData::new(IdentifiedEntry::new(Uuid::nil(), name))),
         )
     }
 
-    fn placeholder_at_index_name(index: HDPathValue, name: &str) -> Self {
-        Self::placeholder_at_index_name_network(NetworkID::Mainnet, index, name)
+    fn placeholder_at_index_name(
+        index: HDPathValue,
+        display_name: &str,
+        name: Name,
+    ) -> Self {
+        Self::placeholder_at_index_name_network(
+            NetworkID::Mainnet,
+            index,
+            display_name,
+            name,
+        )
     }
 
     pub fn placeholder_satoshi() -> Self {
-        Self::placeholder_at_index_name(0, "Satoshi")
+        let name =
+            Name::new(Variant::Eastern, "Nakamoto", "Satoshi", "Satoshi")
+                .expect(
+                "Failure to construct placeholder Name should not be possible",
+            );
+        Self::placeholder_at_index_name(0, "Satoshi", name)
     }
 
     pub fn placeholder_batman() -> Self {
-        Self::placeholder_at_index_name(1, "Batman")
+        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+            .expect(
+                "Failure to construct placeholder Name should not be possible",
+            );
+        Self::placeholder_at_index_name(1, "Batman", name)
     }
 }
-
-// impl Display for Persona {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         write!(f, "{} | {}", self.display_name, self.address)
-//     }
-// }
 
 impl Ord for Persona {
     fn cmp(&self, other: &Self) -> Ordering {
@@ -159,8 +173,6 @@ impl HasPlaceholder for Persona {
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    // use identified_vec::Identifiable;
-    // use std::str::FromStr;
 
     #[test]
     fn equality() {
@@ -297,14 +309,14 @@ mod tests {
                     "id": "00000000-0000-0000-0000-000000000000",
                     "value": {
                       "variant": "Western",
-                      "family_name": "",
-                      "given_name": "",
-                      "nickname": ""
+                      "familyName": "Wayne",
+                      "givenName": "Bruce",
+                      "nickname": "Batman"
                     }
                   }
                 }
               }
-            "#,
+              "#,
         );
     }
 
@@ -353,15 +365,15 @@ mod tests {
                 "name": {
                   "id": "00000000-0000-0000-0000-000000000000",
                   "value": {
-                    "variant": "Western",
-                    "family_name": "",
-                    "given_name": "",
-                    "nickname": ""
+                    "variant": "Eastern",
+                    "familyName": "Nakamoto",
+                    "givenName": "Satoshi",
+                    "nickname": "Satoshi"
                   }
                 }
               }
             }
-        "#,
+            "#,
         );
     }
 
@@ -408,10 +420,10 @@ mod tests {
                 "name": {
                   "id": "00000000-0000-0000-0000-000000000000",
                   "value": {
-                    "variant": "Western",
-                    "familyName": "",
-                    "givenName": "",
-                    "nickname": ""
+                    "variant": "Eastern",
+                    "familyName": "Nakamoto",
+                    "givenName": "Satoshi",
+                    "nickname": "Satoshi"
                   }
                 }
               }
@@ -433,23 +445,32 @@ mod tests {
 
     #[test]
     fn placeholder_stokenet() {
+        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+            .expect("Name counstruction should not fail");
         let persona = Persona::placeholder_at_index_name_network(
             NetworkID::Stokenet,
             1,
             "Batman",
+            name.clone(),
         );
         assert_eq!(persona.display_name.value, "Batman".to_string());
         assert_eq!(persona.network_id, NetworkID::Stokenet);
+        assert_eq!(persona.persona_data.name.value, name);
     }
 
     #[test]
     fn placeholder_stokenet_satoshi() {
+        let name =
+            Name::new(Variant::Western, "Nakamoto", "Satoshi", "Satoshi")
+                .expect("Name counstruction should not fail");
         let persona = Persona::placeholder_at_index_name_network(
             NetworkID::Stokenet,
             0,
             "Satoshi",
+            name.clone(),
         );
         assert_eq!(persona.display_name.value, "Satoshi".to_string());
         assert_eq!(persona.network_id, NetworkID::Stokenet);
+        assert_eq!(persona.persona_data.name.value, name);
     }
 }

--- a/profile/src/v100/entity/persona/persona.rs
+++ b/profile/src/v100/entity/persona/persona.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
 
+use super::persona_data::{IdentifiedEntry, PersonaData};
+
 #[derive(
     Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Eq, uniffi::Record,
 )]
@@ -42,7 +44,6 @@ impl Persona {
     pub fn new(
         persona_creating_factor_instance: HDFactorInstanceIdentityCreation,
         display_name: DisplayName,
-        persona_data: PersonaData,
     ) -> Self {
         let address =
             IdentityAddress::from_hd_factor_instance_virtual_entity_creation(
@@ -58,7 +59,7 @@ impl Persona {
                 )
                 .into(),
             flags: EntityFlags::default(),
-            persona_data,
+            persona_data: PersonaData::new(IdentifiedEntry::default()),
         }
     }
 
@@ -81,7 +82,6 @@ impl Persona {
         Self::new(
             persona_creating_factor_instance,
             DisplayName::new(name).unwrap(),
-            PersonaData::default(),
         )
     }
 
@@ -145,25 +145,14 @@ impl HasPlaceholder for Persona {
     }
 }
 
-/// Empty struct to act as placeholder for PersonaData, `todo`
-#[derive(
-    Serialize,
-    Deserialize,
-    Clone,
-    Debug,
-    PartialEq,
-    Hash,
-    Eq,
-    Default,
-    uniffi::Record,
-)]
-pub struct PersonaData {}
-
 #[cfg(test)]
 mod tests {
     use crate::{
         prelude::*,
-        v100::entity::persona::{Persona, PersonaData},
+        v100::entity::persona::{
+            persona_data::{self, PersonaData},
+            Persona,
+        },
     };
     use identified_vec::Identifiable;
     use std::str::FromStr;
@@ -298,7 +287,17 @@ mod tests {
                   }
                 },
                 "flags": [],
-                "personaData": {}
+                "personaData": {
+                  "name": {
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "value": {
+                      "variant": "Western",
+                      "family_name": "",
+                      "given_name": "",
+                      "nickname": ""
+                    }
+                  }
+                }
               }
             "#,
         );
@@ -311,42 +310,52 @@ mod tests {
             &model,
             r#"
             {
-                "networkID": 1,
-                "address": "identity_rdx122kttqch0eehzj6f9nkkxcw7msfeg9udurq5u0ysa0e92c59w0mg6x",
-                "displayName": "Satoshi",
-                "securityState": {
-                  "discriminator": "unsecured",
-                  "unsecuredEntityControl": {
-                    "transactionSigning": {
-                      "factorSourceID": {
-                        "discriminator": "fromHash",
-                        "fromHash": {
-                          "kind": "device",
-                          "body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
-                        }
-                      },
-                      "badge": {
-                        "discriminator": "virtualSource",
-                        "virtualSource": {
-                          "discriminator": "hierarchicalDeterministicPublicKey",
-                          "hierarchicalDeterministicPublicKey": {
-                            "publicKey": {
-                              "curve": "curve25519",
-                              "compressedData": "983ab1d3a77dd6b30bb8a5d59d490a0380cc0aa9ab464983d3fc581fcf64543f"
-                            },
-                            "derivationPath": {
-                              "scheme": "cap26",
-                              "path": "m/44H/1022H/1H/618H/1460H/0H"
-                            }
+              "networkID": 1,
+              "address": "identity_rdx122kttqch0eehzj6f9nkkxcw7msfeg9udurq5u0ysa0e92c59w0mg6x",
+              "displayName": "Satoshi",
+              "securityState": {
+                "discriminator": "unsecured",
+                "unsecuredEntityControl": {
+                  "transactionSigning": {
+                    "factorSourceID": {
+                      "discriminator": "fromHash",
+                      "fromHash": {
+                        "kind": "device",
+                        "body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+                      }
+                    },
+                    "badge": {
+                      "discriminator": "virtualSource",
+                      "virtualSource": {
+                        "discriminator": "hierarchicalDeterministicPublicKey",
+                        "hierarchicalDeterministicPublicKey": {
+                          "publicKey": {
+                            "curve": "curve25519",
+                            "compressedData": "983ab1d3a77dd6b30bb8a5d59d490a0380cc0aa9ab464983d3fc581fcf64543f"
+                          },
+                          "derivationPath": {
+                            "scheme": "cap26",
+                            "path": "m/44H/1022H/1H/618H/1460H/0H"
                           }
                         }
                       }
                     }
                   }
-                },
-                "flags": [],
-                "personaData": {}
+                }
+              },
+              "flags": [],
+              "personaData": {
+                "name": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "value": {
+                    "variant": "Western",
+                    "family_name": "",
+                    "given_name": "",
+                    "nickname": ""
+                  }
+                }
               }
+            }
         "#,
         );
     }
@@ -356,48 +365,58 @@ mod tests {
         let json = serde_json::from_str(
             r#"
             {
-                "networkID": 1,
-                "address": "identity_rdx12gzxlgre0glhh9jxaptm7tdth8j4w4r8ykpg2xjfv45nghzsjzrvmp",
-                "displayName": "Batman",
-                "securityState": {
-                  "discriminator": "unsecured",
-                  "unsecuredEntityControl": {
-                    "transactionSigning": {
-                      "factorSourceID": {
-                        "discriminator": "fromHash",
-                        "fromHash": {
-                          "kind": "device",
-                          "body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
-                        }
-                      },
-                      "badge": {
-                        "discriminator": "virtualSource",
-                        "virtualSource": {
-                          "discriminator": "hierarchicalDeterministicPublicKey",
-                          "hierarchicalDeterministicPublicKey": {
-                            "publicKey": {
-                              "curve": "curve25519",
-                              "compressedData": "d24cc6af91c3f103d7f46e5691ce2af9fea7d90cfb89a89d5bba4b513b34be3b"
-                            },
-                            "derivationPath": {
-                              "scheme": "cap26",
-                              "path": "m/44H/1022H/1H/525H/1460H/0H"
-                            }
+              "networkID": 1,
+              "address": "identity_rdx122kttqch0eehzj6f9nkkxcw7msfeg9udurq5u0ysa0e92c59w0mg6x",
+              "displayName": "Satoshi",
+              "securityState": {
+                "discriminator": "unsecured",
+                "unsecuredEntityControl": {
+                  "transactionSigning": {
+                    "factorSourceID": {
+                      "discriminator": "fromHash",
+                      "fromHash": {
+                        "kind": "device",
+                        "body": "3c986ebf9dcd9167a97036d3b2c997433e85e6cc4e4422ad89269dac7bfea240"
+                      }
+                    },
+                    "badge": {
+                      "discriminator": "virtualSource",
+                      "virtualSource": {
+                        "discriminator": "hierarchicalDeterministicPublicKey",
+                        "hierarchicalDeterministicPublicKey": {
+                          "publicKey": {
+                            "curve": "curve25519",
+                            "compressedData": "983ab1d3a77dd6b30bb8a5d59d490a0380cc0aa9ab464983d3fc581fcf64543f"
+                          },
+                          "derivationPath": {
+                            "scheme": "cap26",
+                            "path": "m/44H/1022H/1H/618H/1460H/0H"
                           }
                         }
                       }
                     }
                   }
-                },
-                "flags": [],
-                "personaData": {}
+                }
+              },
+              "flags": [],
+              "personaData": {
+                "name": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "value": {
+                    "variant": "Western",
+                    "family_name": "",
+                    "given_name": "",
+                    "nickname": ""
+                  }
+                }
               }
+            }
             "#,
         ).unwrap();
         let persona = serde_json::from_value::<Persona>(json).unwrap();
-        assert_eq!(persona.display_name.value, "Batman".to_string()); // soundness
+        assert_eq!(persona.display_name.value, "Satoshi".to_string()); // soundness
         assert_eq!(persona.flags.len(), 0); // assert Default value is empty flags.
-        assert_eq!(persona.persona_data, PersonaData {}); // assert Default value is empty flags.
+        assert_eq!(persona.persona_data, PersonaData::new(Default::default()));
     }
 
     #[test]

--- a/profile/src/v100/entity/persona/persona_data/entry_kinds/mod.rs
+++ b/profile/src/v100/entity/persona/persona_data/entry_kinds/mod.rs
@@ -1,0 +1,3 @@
+mod name;
+
+pub use name::*;

--- a/profile/src/v100/entity/persona/persona_data/entry_kinds/name.rs
+++ b/profile/src/v100/entity/persona/persona_data/entry_kinds/name.rs
@@ -79,12 +79,6 @@ pub enum Variant {
     Eastern,
 }
 
-impl Default for Variant {
-    fn default() -> Self {
-        Self::Western
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;

--- a/profile/src/v100/entity/persona/persona_data/entry_kinds/name.rs
+++ b/profile/src/v100/entity/persona/persona_data/entry_kinds/name.rs
@@ -1,0 +1,171 @@
+use serde::{Deserialize, Serialize};
+use std::{cmp::Ordering, fmt::Display};
+
+use crate::prelude::*;
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    Hash,
+    Eq,
+    uniffi::Record,
+    Default,
+)]
+pub struct Name {
+    variant: Variant,
+    family_name: String,
+    given_name: String,
+    nickname: String,
+}
+
+impl Name {
+    pub fn new(
+        variant: Variant,
+        family_name: &str,
+        given_name: &str,
+        nickname: &str,
+    ) -> Self {
+        Self {
+            variant,
+            family_name: family_name.to_string(),
+            given_name: given_name.to_string(),
+            nickname: nickname.to_string(),
+        }
+    }
+}
+
+impl Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.variant {
+            Variant::Western => write!(
+                f,
+                "{} {} {}",
+                self.given_name, self.nickname, self.family_name
+            ),
+            Variant::Eastern => write!(
+                f,
+                "{} {} {}",
+                self.family_name, self.nickname, self.given_name
+            ),
+        }
+    }
+}
+
+impl HasPlaceholder for Name {
+    fn placeholder() -> Self {
+        Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+    }
+
+    fn placeholder_other() -> Self {
+        Name::new(Variant::Eastern, "Jun-fan", "Lee", "Bruce")
+    }
+}
+
+#[derive(
+    Serialize, Deserialize, Clone, Debug, PartialEq, Hash, Eq, uniffi::Enum,
+)]
+pub enum Variant {
+    Western,
+    Eastern,
+}
+
+impl Default for Variant {
+    fn default() -> Self {
+        Self::Western
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_eq_after_json_roundtrip, HasPlaceholder};
+
+    #[test]
+    fn new_name() {
+        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman");
+        assert_eq!(name.family_name, "Wayne");
+        assert_eq!(name.given_name, "Bruce");
+        assert_eq!(name.nickname, "Batman");
+    }
+
+    #[test]
+    fn placeholder() {
+        let placeholder = Name::placeholder();
+        assert_eq!(placeholder.family_name, "Wayne");
+        assert_eq!(placeholder.given_name, "Bruce");
+        assert_eq!(placeholder.nickname, "Batman");
+    }
+
+    #[test]
+    fn placeholder_other() {
+        let placeholder = Name::placeholder_other();
+        assert_eq!(placeholder.family_name, "Jun-fan");
+        assert_eq!(placeholder.given_name, "Lee");
+        assert_eq!(placeholder.nickname, "Bruce");
+    }
+
+    #[test]
+    fn name_get_set() {
+        let mut name = Name::placeholder();
+        assert_eq!(name.family_name, "Wayne");
+        assert_eq!(name.given_name, "Bruce");
+        assert_eq!(name.nickname, "Batman");
+        let new_name = Name::new(Variant::Western, "Kent", "Clark", "Superman");
+        name = new_name.clone();
+        assert_eq!(name, new_name);
+    }
+
+    #[test]
+    fn update() {
+        let mut name = Name::placeholder();
+        assert_eq!(name.family_name, "Wayne");
+        let new_name = Name::new(Variant::Western, "Kent", "Clark", "Superman");
+        name.family_name = new_name.family_name;
+        assert_eq!(name.family_name, "Kent");
+    }
+
+    #[test]
+    fn display_western() {
+        let placeholder = Name::placeholder();
+        assert_eq!(format!("{placeholder}"), "Bruce Batman Wayne")
+    }
+
+    #[test]
+    fn display_eastern() {
+        let placeholder = Name::placeholder_other();
+        assert_eq!(format!("{placeholder}"), "Jun-fan Bruce Lee")
+    }
+
+    #[test]
+    fn json_roundtrip_placeholder() {
+        let model = Name::placeholder();
+        assert_eq_after_json_roundtrip(
+            &model,
+            r#"{
+                                "variant": "Western",
+                                "family_name": "Wayne",
+                                "given_name": "Bruce",
+                                "nickname": "Batman"
+                            }
+                            "#,
+        )
+    }
+
+    #[test]
+    fn json_roundtrip_placeholder_other() {
+        let model = Name::placeholder_other();
+        assert_eq_after_json_roundtrip(
+            &model,
+            r#"{
+                                "variant": "Eastern",
+                                "family_name": "Jun-fan",
+                                "given_name": "Lee",
+                                "nickname": "Bruce"
+                            }
+                            "#,
+        )
+    }
+}

--- a/profile/src/v100/entity/persona/persona_data/entry_kinds/name.rs
+++ b/profile/src/v100/entity/persona/persona_data/entry_kinds/name.rs
@@ -39,9 +39,9 @@ impl Name {
         }
         Ok(Self {
             variant,
-            family_name: family_name,
-            given_name: given_name,
-            nickname: nickname,
+            family_name,
+            given_name,
+            nickname,
         })
     }
 
@@ -91,7 +91,8 @@ mod tests {
 
     #[test]
     fn new_name() {
-        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman");
+        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+            .expect("Name construction should not fail");
         assert_eq!(name.family_name, "Wayne");
         assert_eq!(name.given_name, "Bruce");
         assert_eq!(name.nickname, "Batman");
@@ -101,10 +102,11 @@ mod tests {
     fn new_as_ref() {
         let name = Name::new(
             Variant::Western,
-            String::from_str("Wayne").unwrap(),
-            String::from_str("Bruce").unwrap(),
-            String::from_str("Batman").unwrap(),
-        );
+            "Wayne".to_string(),
+            "Bruce".to_string(),
+            "Batman".to_string(),
+        )
+        .expect("Name construction should not fail");
         assert_eq!(name.family_name, "Wayne");
         assert_eq!(name.given_name, "Bruce");
         assert_eq!(name.nickname, "Batman");
@@ -132,7 +134,8 @@ mod tests {
         assert_eq!(name.family_name, "Wayne");
         assert_eq!(name.given_name, "Bruce");
         assert_eq!(name.nickname, "Batman");
-        let new_name = Name::new(Variant::Western, "Kent", "Clark", "Superman");
+        let new_name = Name::new(Variant::Western, "Kent", "Clark", "Superman")
+            .expect("Name construction should not fail");
         name = new_name.clone();
         assert_eq!(name, new_name);
     }
@@ -141,9 +144,28 @@ mod tests {
     fn update() {
         let mut name = Name::placeholder();
         assert_eq!(name.family_name, "Wayne");
-        let new_name = Name::new(Variant::Western, "Kent", "Clark", "Superman");
+        let new_name = Name::new(Variant::Western, "Kent", "Clark", "Superman")
+            .expect("Name construction should not fail");
         name.family_name = new_name.family_name;
         assert_eq!(name.family_name, "Kent");
+    }
+
+    #[test]
+    fn empty_family_name() {
+        let name = Name::new(Variant::Western, "", "Clark", "Superman");
+        assert_eq!(name, Err(CommonError::InvalidDisplayNameEmpty));
+    }
+
+    #[test]
+    fn empty_given_name() {
+        let name = Name::new(Variant::Western, "Kent", "", "Superman");
+        assert_eq!(name, Err(CommonError::InvalidDisplayNameEmpty));
+    }
+
+    #[test]
+    fn empty_nickname() {
+        let name = Name::new(Variant::Western, "Kent", "Clark", "");
+        assert_eq!(name, Err(CommonError::InvalidDisplayNameEmpty));
     }
 
     #[test]
@@ -163,13 +185,14 @@ mod tests {
         let model = Name::placeholder();
         assert_eq_after_json_roundtrip(
             &model,
-            r#"{
-                                "variant": "Western",
-                                "family_name": "Wayne",
-                                "given_name": "Bruce",
-                                "nickname": "Batman"
-                            }
-                            "#,
+            r#"
+            {
+                "variant": "Western",
+                "familyName": "Wayne",
+                "givenName": "Bruce",
+                "nickname": "Batman"
+            }
+            "#,
         )
     }
 
@@ -178,13 +201,14 @@ mod tests {
         let model = Name::placeholder_other();
         assert_eq_after_json_roundtrip(
             &model,
-            r#"{
-                                "variant": "Eastern",
-                                "family_name": "Jun-fan",
-                                "given_name": "Lee",
-                                "nickname": "Bruce"
-                            }
-                            "#,
+            r#"
+            {
+                "variant": "Eastern",
+                "familyName": "Jun-fan",
+                "givenName": "Lee",
+                "nickname": "Bruce"
+            }
+            "#,
         )
     }
 }

--- a/profile/src/v100/entity/persona/persona_data/identified_entry.rs
+++ b/profile/src/v100/entity/persona/persona_data/identified_entry.rs
@@ -1,12 +1,4 @@
-use std::str::FromStr;
-
-use derive_more::Display;
-use serde::{Deserialize, Serialize};
-use uuid::Uuid;
-
-use crate::HasPlaceholder;
-
-use super::{Name, Variant};
+use crate::prelude::*;
 
 type PersonaDataEntryID = Uuid;
 
@@ -19,11 +11,10 @@ type PersonaDataEntryID = Uuid;
     PartialEq,
     Hash,
     Eq,
-    Display,
+    derive_more::Display,
     uniffi::Record,
 )]
-#[display("{} \n id: {}", value, id)]
-#[derive(Default)]
+#[display("{} - {}", value, id)]
 pub struct IdentifiedEntry {
     id: PersonaDataEntryID,
     value: Name,
@@ -104,16 +95,6 @@ mod tests {
             "00000000-0000-0000-0000-000000000002"
         );
         assert_eq!(placeholder.value.to_string(), "Jun-fan Bruce Lee");
-    }
-
-    #[test]
-    fn default() {
-        let default = IdentifiedEntry::default();
-        assert_eq!(
-            default.id.to_string(),
-            "00000000-0000-0000-0000-000000000000"
-        );
-        assert_eq!(default.value.to_string(), "  ")
     }
 
     #[test]

--- a/profile/src/v100/entity/persona/persona_data/identified_entry.rs
+++ b/profile/src/v100/entity/persona/persona_data/identified_entry.rs
@@ -1,0 +1,154 @@
+use std::str::FromStr;
+
+use derive_more::Display;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::HasPlaceholder;
+
+use super::{Name, Variant};
+
+type PersonaDataEntryID = Uuid;
+
+// TODO: Needs to be made generic when adding more entry_kinds. Right now uniffi::Record complains if the function is generic.
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    Hash,
+    Eq,
+    Display,
+    uniffi::Record,
+)]
+#[display("{} \n id: {}", value, id)]
+#[derive(Default)]
+pub struct IdentifiedEntry {
+    id: PersonaDataEntryID,
+    value: Name,
+}
+
+impl IdentifiedEntry {
+    pub fn new(id: PersonaDataEntryID, value: Name) -> Self {
+        Self { id, value }
+    }
+}
+
+impl HasPlaceholder for IdentifiedEntry {
+    fn placeholder() -> Self {
+        IdentifiedEntry::new(
+            Uuid::from_str("00000000-0000-0000-0000-000000000001").unwrap(),
+            Name::placeholder(),
+        )
+    }
+
+    fn placeholder_other() -> Self {
+        IdentifiedEntry::new(
+            Uuid::from_str("00000000-0000-0000-0000-000000000002").unwrap(),
+            Name::placeholder_other(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assert_eq_after_json_roundtrip;
+    use serde_json::json;
+    use std::str::FromStr;
+
+    #[test]
+    fn new() {
+        let identified_entry = IdentifiedEntry::new(
+            Uuid::nil(),
+            Name::new(Variant::Western, "Wayne", "Bruce", "Batman"),
+        );
+        assert_eq!(
+            identified_entry.id,
+            Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap()
+        );
+        assert_eq!(
+            identified_entry.value,
+            Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+        )
+    }
+
+    #[test]
+    fn display() {
+        let identified_entry = IdentifiedEntry::new(
+            Uuid::nil(),
+            Name::new(Variant::Western, "Wayne", "Bruce", "Batman"),
+        );
+        assert_eq!(
+            format!("{identified_entry}"),
+            "Bruce Batman Wayne \n id: 00000000-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn placeholder() {
+        let placeholder = IdentifiedEntry::placeholder();
+        assert_eq!(
+            placeholder.id.to_string(),
+            "00000000-0000-0000-0000-000000000001"
+        );
+        assert_eq!(placeholder.value.to_string(), "Bruce Batman Wayne");
+    }
+
+    #[test]
+    fn placeholder_other() {
+        let placeholder = IdentifiedEntry::placeholder_other();
+        assert_eq!(
+            placeholder.id.to_string(),
+            "00000000-0000-0000-0000-000000000002"
+        );
+        assert_eq!(placeholder.value.to_string(), "Jun-fan Bruce Lee");
+    }
+
+    #[test]
+    fn default() {
+        let default = IdentifiedEntry::default();
+        assert_eq!(
+            default.id.to_string(),
+            "00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(default.value.to_string(), "  ")
+    }
+
+    #[test]
+    fn json_roundtrip_batman() {
+        let model = IdentifiedEntry::placeholder();
+        assert_eq_after_json_roundtrip(
+            &model,
+            r#"{
+            "id": "00000000-0000-0000-0000-000000000001",
+            "value": {
+              "variant": "Western",
+              "family_name": "Wayne",
+              "given_name": "Bruce",
+              "nickname": "Batman"
+            }
+          }
+        "#,
+        )
+    }
+
+    #[test]
+    fn json_roundtrip_bruce_lee() {
+        let model = IdentifiedEntry::placeholder_other();
+        assert_eq_after_json_roundtrip(
+            &model,
+            r#"{
+            "id": "00000000-0000-0000-0000-000000000002",
+            "value": {
+              "variant": "Eastern",
+              "family_name": "Jun-fan",
+              "given_name": "Lee",
+              "nickname": "Bruce"
+            }
+          }
+        "#,
+        )
+    }
+}

--- a/profile/src/v100/entity/persona/persona_data/identified_entry.rs
+++ b/profile/src/v100/entity/persona/persona_data/identified_entry.rs
@@ -16,8 +16,8 @@ type PersonaDataEntryID = Uuid;
 )]
 #[display("{} - {}", value, id)]
 pub struct IdentifiedEntry {
-    id: PersonaDataEntryID,
-    value: Name,
+    pub id: PersonaDataEntryID,
+    pub value: Name,
 }
 
 impl IdentifiedEntry {
@@ -51,29 +51,24 @@ mod tests {
 
     #[test]
     fn new() {
-        let identified_entry = IdentifiedEntry::new(
-            Uuid::nil(),
-            Name::new(Variant::Western, "Wayne", "Bruce", "Batman"),
-        );
+        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+            .expect("Name counstruction should not fail");
+        let identified_entry = IdentifiedEntry::new(Uuid::nil(), name.clone());
         assert_eq!(
             identified_entry.id,
             Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap()
         );
-        assert_eq!(
-            identified_entry.value,
-            Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
-        )
+        assert_eq!(identified_entry.value, name)
     }
 
     #[test]
     fn display() {
-        let identified_entry = IdentifiedEntry::new(
-            Uuid::nil(),
-            Name::new(Variant::Western, "Wayne", "Bruce", "Batman"),
-        );
+        let name = Name::new(Variant::Western, "Wayne", "Bruce", "Batman")
+            .expect("Name counstruction should not fail");
+        let identified_entry = IdentifiedEntry::new(Uuid::nil(), name);
         assert_eq!(
             format!("{identified_entry}"),
-            "Bruce Batman Wayne \n id: 00000000-0000-0000-0000-000000000000"
+            "Bruce Batman Wayne - 00000000-0000-0000-0000-000000000000"
         );
     }
 
@@ -102,16 +97,17 @@ mod tests {
         let model = IdentifiedEntry::placeholder();
         assert_eq_after_json_roundtrip(
             &model,
-            r#"{
-            "id": "00000000-0000-0000-0000-000000000001",
-            "value": {
-              "variant": "Western",
-              "family_name": "Wayne",
-              "given_name": "Bruce",
-              "nickname": "Batman"
-            }
-          }
-        "#,
+            r#"
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "value": {
+                    "variant": "Western",
+                    "familyName": "Wayne",
+                    "givenName": "Bruce",
+                    "nickname": "Batman"
+                }
+             }
+            "#,
         )
     }
 
@@ -120,16 +116,17 @@ mod tests {
         let model = IdentifiedEntry::placeholder_other();
         assert_eq_after_json_roundtrip(
             &model,
-            r#"{
-            "id": "00000000-0000-0000-0000-000000000002",
-            "value": {
-              "variant": "Eastern",
-              "family_name": "Jun-fan",
-              "given_name": "Lee",
-              "nickname": "Bruce"
+            r#"
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "value": {
+                    "variant": "Eastern",
+                    "familyName": "Jun-fan",
+                    "givenName": "Lee",
+                    "nickname": "Bruce"
+                }
             }
-          }
-        "#,
+            "#,
         )
     }
 }

--- a/profile/src/v100/entity/persona/persona_data/mod.rs
+++ b/profile/src/v100/entity/persona/persona_data/mod.rs
@@ -1,0 +1,7 @@
+mod entry_kinds;
+mod identified_entry;
+mod persona_data;
+
+pub use entry_kinds::*;
+pub use identified_entry::*;
+pub use persona_data::*;

--- a/profile/src/v100/entity/persona/persona_data/persona_data.rs
+++ b/profile/src/v100/entity/persona/persona_data/persona_data.rs
@@ -37,9 +37,50 @@ impl HasPlaceholder for PersonaData {
 mod tests {
     use super::*;
 
-    // #[test]
-    // fn new_persona_data() {
-    //     let persona_data = PersonaData::new(IdentifiedEntry::default());
-    //     assert_eq!(persona_data.name, IdentifiedEntry::default());
-    // }
+    #[test]
+    fn equality() {
+        assert_eq!(PersonaData::placeholder(), PersonaData::placeholder());
+        assert_eq!(
+            PersonaData::placeholder_other(),
+            PersonaData::placeholder_other()
+        );
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(
+            PersonaData::placeholder(),
+            PersonaData::placeholder_other()
+        );
+    }
+
+    #[test]
+    fn new_persona_data() {
+        let name =
+            Name::new(Variant::Western, "Skywalker", "Anakin", "Darth Vader")
+                .expect("Name counstruction should not fail");
+        let persona_data =
+            PersonaData::new(IdentifiedEntry::new(Uuid::nil(), name.clone()));
+        assert_eq!(
+            persona_data.name,
+            IdentifiedEntry::new(
+                Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap(),
+                name
+            )
+        );
+    }
+
+    #[test]
+    fn placeholder() {
+        let persona_data = PersonaData::placeholder();
+        let identified_entry = IdentifiedEntry::placeholder();
+        assert_eq!(persona_data.name, identified_entry);
+    }
+
+    #[test]
+    fn placeholder_other() {
+        let persona_data = PersonaData::placeholder_other();
+        let identified_entry = IdentifiedEntry::placeholder_other();
+        assert_eq!(persona_data.name, identified_entry);
+    }
 }

--- a/profile/src/v100/entity/persona/persona_data/persona_data.rs
+++ b/profile/src/v100/entity/persona/persona_data/persona_data.rs
@@ -1,6 +1,4 @@
-use super::IdentifiedEntry;
-use derive_more::Display;
-use serde::{Deserialize, Serialize};
+use crate::prelude::*;
 
 #[derive(
     Serialize,
@@ -10,11 +8,11 @@ use serde::{Deserialize, Serialize};
     PartialEq,
     Hash,
     Eq,
-    Display,
+    derive_more::Display,
     uniffi::Record,
 )]
 #[display("{}", name)]
-#[derive(Default)]
+#[serde(rename_all = "camelCase")]
 pub struct PersonaData {
     pub name: IdentifiedEntry,
 }
@@ -25,13 +23,23 @@ impl PersonaData {
     }
 }
 
+impl HasPlaceholder for PersonaData {
+    fn placeholder() -> Self {
+        Self::new(IdentifiedEntry::placeholder())
+    }
+
+    fn placeholder_other() -> Self {
+        Self::new(IdentifiedEntry::placeholder_other())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn new_persona_data() {
-        let persona_data = PersonaData::new(IdentifiedEntry::default());
-        assert_eq!(persona_data.name, IdentifiedEntry::default());
-    }
+    // #[test]
+    // fn new_persona_data() {
+    //     let persona_data = PersonaData::new(IdentifiedEntry::default());
+    //     assert_eq!(persona_data.name, IdentifiedEntry::default());
+    // }
 }

--- a/profile/src/v100/entity/persona/persona_data/persona_data.rs
+++ b/profile/src/v100/entity/persona/persona_data/persona_data.rs
@@ -1,0 +1,37 @@
+use super::IdentifiedEntry;
+use derive_more::Display;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    Hash,
+    Eq,
+    Display,
+    uniffi::Record,
+)]
+#[display("{}", name)]
+#[derive(Default)]
+pub struct PersonaData {
+    pub name: IdentifiedEntry,
+}
+
+impl PersonaData {
+    pub fn new(name: IdentifiedEntry) -> Self {
+        Self { name }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_persona_data() {
+        let persona_data = PersonaData::new(IdentifiedEntry::default());
+        assert_eq!(persona_data.name, IdentifiedEntry::default());
+    }
+}


### PR DESCRIPTION
# Implement PersonaData (with IdentifiedEntry and Name)

Implementation of PersonaData with just IdentifiedEntry and Name. 
Documentation and Bindgen tests still to be added.