### PR TITLE
Mutable records and add `update_account` to Wallet.

### DIFF
--- a/profile/src/hierarchical_deterministic/bip39/bip39_passphrase.rs
+++ b/profile/src/hierarchical_deterministic/bip39/bip39_passphrase.rs
@@ -1,5 +1,8 @@
 use crate::prelude::*;
 
+// Generate the FfiConverter needed by UniFFI for newtype `BIP39Passphrase`.
+uniffi::custom_newtype!(BIP39Passphrase, String);
+
 /// A BIP39 passphrase, which required but when not used by user, the Default value will be use (empty string),
 /// as per BIP39 standard.
 #[derive(
@@ -65,8 +68,6 @@ impl Default for BIP39Passphrase {
         Self("".to_string())
     }
 }
-
-uniffi::custom_newtype!(BIP39Passphrase, String);
 
 #[cfg(test)]
 mod tests {

--- a/profile/src/v100/entity/account/appearance_id.rs
+++ b/profile/src/v100/entity/account/appearance_id.rs
@@ -21,6 +21,21 @@ pub struct AppearanceID {
     pub value: u8,
 }
 
+#[uniffi::export]
+pub fn new_appearance_id(validating: u8) -> Result<AppearanceID> {
+    AppearanceID::new(validating)
+}
+
+#[uniffi::export]
+pub fn new_appearance_id_placeholder() -> AppearanceID {
+    AppearanceID::placeholder()
+}
+
+#[uniffi::export]
+pub fn new_appearance_id_placeholder_other() -> AppearanceID {
+    AppearanceID::placeholder_other()
+}
+
 impl AppearanceID {
     /// The number of different appearances
     pub const MAX: u8 = 11;
@@ -35,6 +50,56 @@ impl AppearanceID {
         Self {
             value: (n % (Self::MAX as usize)) as u8,
         }
+    }
+
+    // Probably want this as a macro... but it is just not worth it, why I boilerplate it.
+    fn declare(value: u8) -> Self {
+        Self::new(value).expect("Should have declared valid value.")
+    }
+    pub fn gradient0() -> Self {
+        Self::declare(0)
+    }
+    pub fn gradient1() -> Self {
+        Self::declare(1)
+    }
+    pub fn gradient2() -> Self {
+        Self::declare(2)
+    }
+    pub fn gradient3() -> Self {
+        Self::declare(3)
+    }
+    pub fn gradient4() -> Self {
+        Self::declare(4)
+    }
+    pub fn gradient5() -> Self {
+        Self::declare(5)
+    }
+    pub fn gradient6() -> Self {
+        Self::declare(6)
+    }
+    pub fn gradient7() -> Self {
+        Self::declare(7)
+    }
+    pub fn gradient8() -> Self {
+        Self::declare(8)
+    }
+    pub fn gradient9() -> Self {
+        Self::declare(9)
+    }
+    pub fn gradient10() -> Self {
+        Self::declare(10)
+    }
+    pub fn gradient11() -> Self {
+        Self::declare(11)
+    }
+}
+
+impl HasPlaceholder for AppearanceID {
+    fn placeholder() -> Self {
+        Self::gradient0()
+    }
+    fn placeholder_other() -> Self {
+        Self::gradient11()
     }
 }
 
@@ -61,6 +126,24 @@ impl From<AppearanceID> for u8 {
 mod tests {
 
     use crate::prelude::*;
+
+    #[test]
+    fn equality() {
+        assert_eq!(AppearanceID::placeholder(), AppearanceID::placeholder());
+        assert_eq!(
+            AppearanceID::placeholder_other(),
+            AppearanceID::placeholder_other()
+        );
+    }
+
+    #[test]
+    fn inequality() {
+        assert_ne!(
+            AppearanceID::placeholder(),
+            AppearanceID::placeholder_other()
+        );
+    }
+
     #[test]
     fn lowest() {
         assert!(AppearanceID::new(0).is_ok());
@@ -101,5 +184,45 @@ mod tests {
         );
         assert_json_value_fails::<AppearanceID>(json!("3"));
         assert_json_value_fails::<AppearanceID>(json!(99));
+    }
+
+    #[test]
+    fn presets() {
+        let set = [
+            AppearanceID::gradient0(),
+            AppearanceID::gradient1(),
+            AppearanceID::gradient2(),
+            AppearanceID::gradient3(),
+            AppearanceID::gradient4(),
+            AppearanceID::gradient5(),
+            AppearanceID::gradient6(),
+            AppearanceID::gradient7(),
+            AppearanceID::gradient8(),
+            AppearanceID::gradient9(),
+            AppearanceID::gradient10(),
+            AppearanceID::gradient11(),
+        ]
+        .into_iter()
+        .map(|a| a.value)
+        .collect::<HashSet<_>>();
+        assert_eq!(set.len(), (AppearanceID::MAX as usize) + 1);
+    }
+}
+
+#[cfg(test)]
+mod uniffi_tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn new() {
+        assert_eq!(new_appearance_id(5).unwrap(), AppearanceID::gradient5());
+    }
+
+    #[test]
+    fn placeholders() {
+        assert_ne!(
+            new_appearance_id_placeholder(),
+            new_appearance_id_placeholder_other()
+        );
     }
 }

--- a/profile/tests/uniffi/bindings/test_wallet.swift
+++ b/profile/tests/uniffi/bindings/test_wallet.swift
@@ -43,8 +43,30 @@ func test() throws {
 	assert(keychain.contains(value: initialNameOfFirstAccount))
 	print("✨ Successfully created first account ✅")
 	// MARK: ==================================
-	print("🔮 Renaming account")
-	let updatedNameOfFirstAccount = "Satoshi"
+	print("🔮 Update account using `update_account`")
+	var updatedNameOfFirstAccount = "Stella"
+	main0.displayName = try DisplayName(validating: updatedNameOfFirstAccount)
+	main0.appearanceId = .placeholderOther
+	let main0Updated = try wallet.updateAccount(to: main0)
+	assert(main0Updated == main0)
+	assert(
+		wallet.profile().networks[0].accounts[0].displayName.value
+			== updatedNameOfFirstAccount
+	)
+	assert(
+		wallet.profile().networks[0].accounts[0].appearanceId
+			== .placeholderOther
+	)
+
+	assert(
+		keychain.contains(
+			value: updatedNameOfFirstAccount
+		))
+	print("✨ Successfully updated first account using `update_account` ✅")
+
+	// MARK: ==================================
+	print("🔮 Renaming account using changeNameOfAccount")
+	updatedNameOfFirstAccount = "Satoshi"
 	main0 = try wallet.changeNameOfAccount(
 		address: main0.address,
 		to: DisplayName(
@@ -58,7 +80,7 @@ func test() throws {
 		keychain.contains(
 			value: updatedNameOfFirstAccount
 		))
-	print("✨ Successfully renamed first account ✅")
+	print("✨ Successfully renamed first account using changeNameOfAccount ✅")
 	// MARK: ==================================
 	print("🔮 Creating second mainnet account")
 	let main1 = try wallet.createAndSaveNewAccount(
@@ -111,6 +133,11 @@ extension DisplayName {
 	init(validating value: String) throws {
 		self = try newDisplayName(name: value)
 	}
+}
+typealias AppearanceID = AppearanceId
+extension AppearanceID {
+	static let placeholder: Self = newAppearanceIdPlaceholder()
+	static let placeholderOther: Self = newAppearanceIdPlaceholderOther()
 }
 extension Data {
 	public static func random(byteCount: Int) throws -> Self {

--- a/profile/uniffi.toml
+++ b/profile/uniffi.toml
@@ -1,5 +1,8 @@
 [bindings.swift]
-generate_immutable_records = true
+# Actually `generate_immutable_records` is `false` by default, but wanted a natural place to document it, our 
+# clients must be able to pass an updated value, e.g. `update_account(updated_account)` and before have
+# mutated the stored properties on account.
+generate_immutable_records = false
 
 [bindings.swift.custom_types.Uuid]
 # Name of the type in the Swift code


### PR DESCRIPTION
Changes from Swift/Kotlin structs stored properties being generated as `let` to `var`, making it possible for us to mutate values Client-Side and then do whole update of it using Sargon, like so:

```swift
var main0 = try wallet.createAndSaveNewAccount(
	networkId: .mainnet,
	name: DisplayName(
		validating: "Mario"
	)
)
let updatedNameOfFirstAccount = "Stella"

// Update `main0` account here Client-side (since stored properties are now mutable!)
main0.displayName = try DisplayName(validating: updatedNameOfFirstAccount)
main0.appearanceId = .placeholderOther

// Commit change by calling `Sargon`'s method `updateAccount` on `wallet`!
let main0Updated = try wallet.updateAccount(to: main0)

// Asserts correct..
assert(main0Updated == main0)
assert(
	wallet.profile().networks[0].accounts[0].displayName.value
		== updatedNameOfFirstAccount
)
assert(
	wallet.profile().networks[0].accounts[0].appearanceId
		== .placeholderOther
)

```