### PR TITLE
Add Kotlin script tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /Cargo.lock
 tarpaulin-report.html
 .vscode
+.idea
 build_rs_cov.profraw
 cobertura.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tarpaulin-report.html
 .idea
 build_rs_cov.profraw
 cobertura.xml
+jna-*.jar

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,5 +44,5 @@ repos:
         name: uniffi bindgen tests
         language: system
         types: [file, rust]
-        entry: cargo test --package profile --test uniffi
+        entry: bash -c 'exec env CLASSPATH="$PWD/jna-5.13.0.jar"' && bash -c 'exec env JAVA_OPTS="-Xmx8g"' && cargo test --package profile --test uniffi
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -183,3 +183,13 @@ cargo install cargo-nextest
 ```sh
 cargo nextest run --package profile --test uniffi && cargo nextest run
 ```
+
+> [!IMPORTANT]  
+> To run tests in Kotlin you need to download [JNA](https://mvnrepository.com/artifact/net.java.dev.jna/jna) (currently tested under version `5.13.0`) 
+> ``` sh
+> wget https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar
+> ```
+> Then include the jar into the classpath and also increase the heap size like so
+> ```sh
+> JAVA_OPTS="-Xmx8g" CLASSPATH="path-to-jna/jna-5.13.0.jar" cargo nextest run --package profile --test uniffi && cargo nextest run
+> ```

--- a/profile/src/hierarchical_deterministic/cap26/cap26_path/cap26_path.rs
+++ b/profile/src/hierarchical_deterministic/cap26/cap26_path/cap26_path.rs
@@ -21,9 +21,9 @@ pub enum CAP26Path {
     #[display("{value}")]
     GetID { value: GetIDPath },
     #[display("{value}")]
-    AccountPath { value: AccountPath },
+    Account { value: AccountPath },
     #[display("{value}")]
-    IdentityPath { value: IdentityPath },
+    Identity { value: IdentityPath },
 }
 
 impl TryFrom<&HDPath> for CAP26Path {
@@ -50,8 +50,8 @@ impl FromStr for CAP26Path {
 impl Derivation for CAP26Path {
     fn hd_path(&self) -> &HDPath {
         match self {
-            CAP26Path::AccountPath { value } => value.hd_path(),
-            CAP26Path::IdentityPath { value } => value.hd_path(),
+            CAP26Path::Account { value } => value.hd_path(),
+            CAP26Path::Identity { value } => value.hd_path(),
             CAP26Path::GetID { value } => value.hd_path(),
         }
     }
@@ -64,8 +64,8 @@ impl Derivation for CAP26Path {
 
     fn scheme(&self) -> DerivationPathScheme {
         match self {
-            CAP26Path::AccountPath { value } => value.scheme(),
-            CAP26Path::IdentityPath { value } => value.scheme(),
+            CAP26Path::Account { value } => value.scheme(),
+            CAP26Path::Identity { value } => value.scheme(),
             CAP26Path::GetID { value } => value.scheme(),
         }
     }
@@ -73,13 +73,13 @@ impl Derivation for CAP26Path {
 
 impl From<AccountPath> for CAP26Path {
     fn from(value: AccountPath) -> Self {
-        Self::AccountPath { value }
+        Self::Account { value }
     }
 }
 
 impl From<IdentityPath> for CAP26Path {
     fn from(value: IdentityPath) -> Self {
-        Self::IdentityPath { value }
+        Self::Identity { value }
     }
 }
 
@@ -101,13 +101,13 @@ impl HasPlaceholder for CAP26Path {
 
 impl CAP26Path {
     pub fn placeholder_account() -> Self {
-        Self::AccountPath {
+        Self::Account {
             value: AccountPath::placeholder(),
         }
     }
 
     pub fn placeholder_identity() -> Self {
-        Self::IdentityPath {
+        Self::Identity {
             value: IdentityPath::placeholder(),
         }
     }
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn into_from_account_path() {
         assert_eq!(
-            CAP26Path::AccountPath {
+            CAP26Path::Account {
                 value: AccountPath::placeholder()
             },
             AccountPath::placeholder().into()

--- a/profile/src/hierarchical_deterministic/cap26/cap26_path/paths/account_path.rs
+++ b/profile/src/hierarchical_deterministic/cap26/cap26_path/paths/account_path.rs
@@ -45,7 +45,7 @@ impl TryFrom<CAP26Path> for AccountPath {
 
     fn try_from(value: CAP26Path) -> Result<Self, Self::Error> {
         value
-            .as_account_path()
+            .as_account()
             .ok_or(CommonError::ExpectedAccountPathButGotSomethingElse)
             .cloned()
     }
@@ -106,7 +106,7 @@ impl Derivation for AccountPath {
     }
     fn derivation_path(&self) -> DerivationPath {
         DerivationPath::CAP26 {
-            value: CAP26Path::AccountPath {
+            value: CAP26Path::Account {
                 value: self.clone(),
             },
         }

--- a/profile/src/hierarchical_deterministic/cap26/cap26_path/paths/identity_path.rs
+++ b/profile/src/hierarchical_deterministic/cap26/cap26_path/paths/identity_path.rs
@@ -45,7 +45,7 @@ impl TryFrom<CAP26Path> for IdentityPath {
 
     fn try_from(value: CAP26Path) -> Result<Self, Self::Error> {
         value
-            .as_identity_path()
+            .as_identity()
             .ok_or(CommonError::ExpectedIdentityPathButGotSomethingElse)
             .cloned()
     }
@@ -106,7 +106,7 @@ impl Derivation for IdentityPath {
 
     fn derivation_path(&self) -> DerivationPath {
         DerivationPath::CAP26 {
-            value: CAP26Path::IdentityPath {
+            value: CAP26Path::Identity {
                 value: self.clone(),
             },
         }

--- a/profile/src/hierarchical_deterministic/derivation/derivation_path.rs
+++ b/profile/src/hierarchical_deterministic/derivation/derivation_path.rs
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn from_cap26() {
-        let derivation_path: DerivationPath = CAP26Path::AccountPath {
+        let derivation_path: DerivationPath = CAP26Path::Account {
             value: AccountPath::placeholder(),
         }
         .into();
@@ -304,7 +304,7 @@ mod tests {
         let path: DerivationPath = AccountPath::placeholder().into();
         assert_eq!(
             path.as_cap26().unwrap(),
-            &CAP26Path::AccountPath {
+            &CAP26Path::Account {
                 value: AccountPath::placeholder()
             }
         );

--- a/profile/src/v100/entity/account/account.rs
+++ b/profile/src/v100/entity/account/account.rs
@@ -383,7 +383,7 @@ mod tests {
         let new_third_party_dep = ThirdPartyDeposits::with_rule_and_lists(
             DepositRule::DenyAll,
             [excp1, excp2],
-            [DepositorAddress::ResourceAddress {
+            [DepositorAddress::Resource {
                 value: "resource_rdx1tkk83magp3gjyxrpskfsqwkg4g949rmcjee4tu2xmw93ltw2cz94sq"
                     .parse()
                     .unwrap(),

--- a/profile/src/v100/entity/account/on_ledger_settings/on_ledger_settings.rs
+++ b/profile/src/v100/entity/account/on_ledger_settings/on_ledger_settings.rs
@@ -101,7 +101,7 @@ mod tests {
             DepositRule::DenyAll,
             Vec::from_iter([excp1, excp2]),
             Vec::from_iter(
-                [DepositorAddress::ResourceAddress {
+                [DepositorAddress::Resource {
                     value: "resource_rdx1tkk83magp3gjyxrpskfsqwkg4g949rmcjee4tu2xmw93ltw2cz94sq"
                         .parse()
                         .unwrap(),

--- a/profile/src/v100/entity/account/on_ledger_settings/third_party_deposits/depositor_address.rs
+++ b/profile/src/v100/entity/account/on_ledger_settings/third_party_deposits/depositor_address.rs
@@ -13,11 +13,12 @@ use crate::prelude::*;
     Ord,
     uniffi::Enum,
 )]
-#[serde(rename_all = "camelCase")]
 #[serde(tag = "discriminator")]
 pub enum DepositorAddress {
-    ResourceAddress { value: ResourceAddress },
-    NonFungibleGlobalID { value: NonFungibleGlobalId },
+    #[serde(rename = "resourceAddress")]
+    Resource { value: ResourceAddress },
+    #[serde(rename = "nonFungibleGlobalID")]
+    NFGlobalID { value: NonFungibleGlobalId },
 }
 
 #[cfg(test)]
@@ -26,7 +27,7 @@ mod tests {
     #[test]
     fn json_decode_deny_all_with_exceptions() {
         let model =
-            DepositorAddress::ResourceAddress {
+            DepositorAddress::Resource {
                 value: "resource_rdx1tkk83magp3gjyxrpskfsqwkg4g949rmcjee4tu2xmw93ltw2cz94sq"
                     .parse()
                     .unwrap(),

--- a/profile/src/v100/entity/account/on_ledger_settings/third_party_deposits/third_party_deposits.rs
+++ b/profile/src/v100/entity/account/on_ledger_settings/third_party_deposits/third_party_deposits.rs
@@ -125,7 +125,7 @@ mod tests {
             DepositRule::AcceptKnown,
             BTreeSet::from_iter([excp1, excp2]),
             BTreeSet::from_iter(
-                [DepositorAddress::NonFungibleGlobalID { value: "resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:<foobar>".parse().unwrap()}],
+                [DepositorAddress::NFGlobalID { value: "resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:<foobar>".parse().unwrap()}],
             ),
         );
 
@@ -215,7 +215,7 @@ mod tests {
         )
         .unwrap();
 
-        let depositor = DepositorAddress::NonFungibleGlobalID {
+        let depositor = DepositorAddress::NFGlobalID {
             value: "resource_sim1ngktvyeenvvqetnqwysevcx5fyvl6hqe36y3rkhdfdn6uzvt5366ha:<foobar>"
                 .parse()
                 .unwrap(),

--- a/profile/src/v100/factors/hierarchical_deterministic_factor_instance.rs
+++ b/profile/src/v100/factors/hierarchical_deterministic_factor_instance.rs
@@ -80,8 +80,8 @@ impl HierarchicalDeterministicFactorInstance {
         match &self.derivation_path() {
             DerivationPath::CAP26 { value } => match value {
                 CAP26Path::GetID { value: _ } => None,
-                CAP26Path::IdentityPath { value } => Some(value.key_kind()),
-                CAP26Path::AccountPath { value } => Some(value.key_kind()),
+                CAP26Path::Identity { value } => Some(value.key_kind()),
+                CAP26Path::Account { value } => Some(value.key_kind()),
             },
             DerivationPath::BIP44Like { value: _ } => None,
         }

--- a/profile/tests/uniffi/bindings/test_account_address.kts
+++ b/profile/tests/uniffi/bindings/test_account_address.kts
@@ -1,4 +1,4 @@
-import uniffi.radix_wallet_kit.*
+import radix.wallet.kit.*
 
 fun testAddress() {
     val bech32 = "account_rdx129qdd2yp9vs8jkkn2uwn6sw0ejwmcwr3r4c3usr2hp0nau67m2kzdm"

--- a/profile/tests/uniffi/bindings/test_account_address.kts
+++ b/profile/tests/uniffi/bindings/test_account_address.kts
@@ -1,0 +1,25 @@
+import uniffi.radix_wallet_kit.*
+
+fun testAddress() {
+    val bech32 = "account_rdx129qdd2yp9vs8jkkn2uwn6sw0ejwmcwr3r4c3usr2hp0nau67m2kzdm"
+	val key = newEd25519PublicKeyFromHex(
+		hex = "3e9b96a2a863f1be4658ea66aa0584d2a8847d4c0f658b20e62e3594d994d73d"
+    )
+
+	val address0 = newAccountAddressFrom(
+        publicKey = PublicKey.Ed25519(value = key),
+        networkId = NetworkId.MAINNET
+    )
+    assert(address0.address == bech32)
+
+    val address1 = newAccountAddress(bech32 = bech32)
+    assert(address1.address == bech32)
+    assert(accountAddressToShort(address = address1) == "acco...m2kzdm")
+    assert(address1.networkId == NetworkId.MAINNET)
+}
+
+fun test() {
+	testAddress()
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_app_preferences.kts
+++ b/profile/tests/uniffi/bindings/test_app_preferences.kts
@@ -1,4 +1,4 @@
-import uniffi.radix_wallet_kit.*
+import radix.wallet.kit.*
 
 val AppPreferences.Companion.placeholder
     get() = newAppPreferencesPlaceholder()

--- a/profile/tests/uniffi/bindings/test_app_preferences.kts
+++ b/profile/tests/uniffi/bindings/test_app_preferences.kts
@@ -1,0 +1,32 @@
+import uniffi.radix_wallet_kit.*
+
+val AppPreferences.Companion.placeholder
+    get() = newAppPreferencesPlaceholder()
+
+val AppPreferences.Companion.placeholderOther
+    get() = newAppPreferencesPlaceholderOther()
+
+fun test_equals() {
+	val a = AppPreferences.placeholder
+	val b = AppPreferences.placeholderOther
+
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+	//assert(a == AppPreferences.placeholder)
+	assert(a != b)
+	//assert(b == AppPreferences.placeholderOther)
+}
+
+fun test_hashCode() {
+	val a = AppPreferences.placeholder
+	val b = AppPreferences.placeholderOther
+	assert(setOf(a, a).size == 1)
+	assert(setOf(b, b).size == 1)
+	assert(setOf(a, b, b, a).size == 2)
+}
+
+fun test() {
+	test_equals()
+	test_hashCode()
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_factor_sources.kts
+++ b/profile/tests/uniffi/bindings/test_factor_sources.kts
@@ -1,0 +1,32 @@
+import uniffi.radix_wallet_kit.*
+
+val placeholder: List<FactorSource>
+    get() = newFactorSourcesPlaceholder()
+
+val placeholderOther: List<FactorSource>
+    get() = newFactorSourcesPlaceholderOther()
+
+fun test_equals() {
+	val a = placeholder
+	val b = placeholderOther
+
+	// TODO will change these when HexCoded32Bytes is represented with a list of bytes
+	//assert(a == placeholder)
+	assert(a != b)
+	//assert(b == placeholderOther)
+}
+
+fun test_hashCode() {
+	val a = placeholder
+	val b = placeholderOther
+	assert(setOf(a, a).size == 1)
+	assert(setOf(b, b).size == 1)
+	assert(setOf(a, b, b, a).size == 2)
+}
+
+fun test() {
+	test_equals()
+	test_hashCode()
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_factor_sources.kts
+++ b/profile/tests/uniffi/bindings/test_factor_sources.kts
@@ -1,4 +1,4 @@
-import uniffi.radix_wallet_kit.*
+import radix.wallet.kit.*
 
 val placeholder: List<FactorSource>
     get() = newFactorSourcesPlaceholder()

--- a/profile/tests/uniffi/bindings/test_gateways.kts
+++ b/profile/tests/uniffi/bindings/test_gateways.kts
@@ -1,0 +1,39 @@
+import uniffi.radix_wallet_kit.*
+
+val Gateways.Companion.placeholder
+    get() = newGatewaysPlaceholder()
+
+val Gateways.Companion.placeholderOther
+    get() = newGatewaysPlaceholderOther()
+
+fun test_equals() {
+	val a = Gateways.placeholder
+	val b = Gateways.placeholderOther
+
+	assert(a == Gateways.placeholder)
+	assert(a != b)
+	assert(b == Gateways.placeholderOther)
+}
+
+fun test_hashCode() {
+	val a = Gateways.placeholder
+	val b = Gateways.placeholderOther
+	assert(setOf(a, a).size == 1)
+	assert(setOf(b, b).size == 1)
+	assert(setOf(a, b, b, a).size == 2)
+}
+
+fun test_new() {
+	val mainnet = gatewayMainnet()
+	assert(mainnet == gatewayMainnet())
+	val gateways = newGateways(current = mainnet)
+	assert(gateways.current.network.id == NetworkId.MAINNET)
+}
+
+fun test() {
+	test_equals()
+	test_hashCode()
+	test_new()
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_gateways.kts
+++ b/profile/tests/uniffi/bindings/test_gateways.kts
@@ -1,4 +1,4 @@
-import uniffi.radix_wallet_kit.*
+import radix.wallet.kit.*
 
 val Gateways.Companion.placeholder
     get() = newGatewaysPlaceholder()

--- a/profile/tests/uniffi/bindings/test_header.kts
+++ b/profile/tests/uniffi/bindings/test_header.kts
@@ -1,4 +1,4 @@
-import uniffi.radix_wallet_kit.*
+import radix.wallet.kit.*
 
 val Header.Companion.placeholder
     get() = newHeaderPlaceholder()

--- a/profile/tests/uniffi/bindings/test_header.kts
+++ b/profile/tests/uniffi/bindings/test_header.kts
@@ -1,0 +1,32 @@
+import uniffi.radix_wallet_kit.*
+
+val Header.Companion.placeholder
+    get() = newHeaderPlaceholder()
+
+val Header.Companion.placeholderOther
+    get() = newHeaderPlaceholderOther()
+
+fun test_equals() {
+	val a = Header.placeholder
+	val b = Header.placeholderOther
+
+	assert(a == Header.placeholder)
+	assert(a != b)
+	assert(b == Header.placeholderOther)
+}
+
+fun test_hashCode() {
+	val a = Header.placeholder
+	val b = Header.placeholderOther
+
+	assert(setOf(a, a).size == 1)
+	assert(setOf(b, b).size == 1)
+	assert(setOf(a, b, b, a).size == 2)
+}
+
+fun test() {
+	test_equals()
+	test_hashCode()
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_hex32_bytes.kts
+++ b/profile/tests/uniffi/bindings/test_hex32_bytes.kts
@@ -1,0 +1,20 @@
+import radix.wallet.kit.*
+import kotlin.random.Random
+
+fun randomByteArray(byteCount: Int): ByteArray {
+    val bytes = ByteArray(byteCount)
+    return Random.nextBytes(bytes)
+}
+
+fun Hex32Bytes.Companion.init(bytes: ByteArray): Hex32Bytes = newHex32BytesFrom(bytes = bytes)
+
+fun test() {
+    val bytes = randomByteArray(byteCount = 32)
+    val hex32 = Hex32Bytes.init(bytes = bytes)
+
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+    //assert(hex32.bytes == bytes)
+    assert(hex32.bytes.contentEquals(bytes))
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_keys.kts
+++ b/profile/tests/uniffi/bindings/test_keys.kts
@@ -1,0 +1,77 @@
+import radix.wallet.kit.*
+
+fun String.hexToByteArray(): ByteArray {
+    check(length % 2 == 0) { "Must have an even length" }
+
+    return chunked(2)
+        .map { it.toInt(16).toByte() }
+        .toByteArray()
+}
+
+fun ByteArray.toHex(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
+
+fun PublicKey.toHex(): String = when (this) {
+    is PublicKey.Ed25519 -> ed25519PublicKeyToHex(publicKey = this.value)
+    is PublicKey.Secp256k1 -> secp256k1PublicKeyToHex(publicKey = this.value)
+}
+
+fun PublicKey.toBytes(): ByteArray = when (this) {
+    is PublicKey.Ed25519 -> ed25519PublicKeyToBytes(publicKey = this.value)
+    is PublicKey.Secp256k1 -> secp256k1PublicKeyToBytes(publicKey = this.value)
+}
+
+inline fun <reified K: PublicKey> testKey(hex: String): PublicKey {
+	val bytes = hex.hexToByteArray()
+	assert(bytes.toHex() == hex)
+
+    val pk0 = when (K::class.java) {
+        PublicKey.Ed25519::class.java -> PublicKey.Ed25519(newEd25519PublicKeyFromHex(hex = hex))
+        PublicKey.Secp256k1::class.java -> PublicKey.Secp256k1(newSecp256k1PublicKeyFromHex(hex = hex))
+        else -> error("Not a valid PublicKey class")
+    }
+	assert(pk0.toHex() == hex)
+	// TODO will change these when HexCoded32Bytes is represented with a list of bytes
+	//assert(pk0.toBytes() == bytes)
+	assert(pk0.toBytes().contentEquals(bytes))
+
+    val pk1 = when (K::class.java) {
+        PublicKey.Ed25519::class.java -> PublicKey.Ed25519(newEd25519PublicKeyFromBytes(bytes = bytes))
+        PublicKey.Secp256k1::class.java -> PublicKey.Secp256k1(newSecp256k1PublicKeyFromBytes(bytes = bytes))
+        else -> error("Not a valid PublicKey class")
+    }
+	assert(pk1.toHex() == hex)
+	// TODO will change these when HexCoded32Bytes is represented with a list of bytes
+	//assert(pk1.toBytes() == bytes)
+    assert(pk1.toBytes().contentEquals(bytes))
+
+	return pk0
+}
+
+fun testKeysCurve25519() {
+	val hex = "ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf"
+	val key = testKey<PublicKey.Ed25519>(hex = hex)
+	when (key) {
+        is PublicKey.Ed25519 -> assert(key.toHex() == hex)
+        is PublicKey.Secp256k1 -> error("Expected Ed25519 key")
+    }
+}
+
+fun testKeysSecp256k1() {
+	val hex = "02517b88916e7f315bb682f9926b14bc67a0e4246f8a419b986269e1a7e61fffa7"
+	val key = testKey<PublicKey.Secp256k1>(hex = hex)
+	when (key) {
+	    is PublicKey.Secp256k1 -> assert(key.toHex() == hex)
+	    is PublicKey.Ed25519 -> error("Expected secp256k1 key")
+	}
+}
+
+fun testKeys() {
+	testKeysCurve25519()
+	testKeysSecp256k1()
+}
+
+fun test() {
+	testKeys()
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_profile.kts
+++ b/profile/tests/uniffi/bindings/test_profile.kts
@@ -1,0 +1,35 @@
+import radix.wallet.kit.*
+
+val Profile.Companion.placeholder
+    get() = newProfilePlaceholder()
+
+val Profile.Companion.placeholderOther
+    get() = newProfilePlaceholderOther()
+
+fun test_equals() {
+	val p = Profile.placeholder
+	val q = Profile.placeholderOther
+
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+	//assert(p == Profile.placeholder)
+	assert(p != q)
+	// TODO will change these when HexCoded32Bytes is represented with a list of bytes
+	//assert(q == Profile.placeholderOther)
+}
+
+fun test_hashCode() {
+	val a = Profile.placeholder
+	val b = Profile.placeholderOther
+
+	assert(setOf(a, a).size == 1)
+	assert(setOf(b, b).size == 1)
+	assert(setOf(a, b, b, a).size == 2)
+}
+
+fun test() {
+	test_equals()
+	test_hashCode()
+}
+
+
+test()

--- a/profile/tests/uniffi/bindings/test_radix_connect_password.kts
+++ b/profile/tests/uniffi/bindings/test_radix_connect_password.kts
@@ -1,0 +1,18 @@
+import radix.wallet.kit.*
+import kotlin.random.Random
+
+fun randomByteArray(byteCount: Int): ByteArray {
+    val bytes = ByteArray(byteCount)
+    return Random.nextBytes(bytes)
+}
+
+fun test() {
+    val byteArray = randomByteArray(byteCount = 32)
+    val password = RadixConnectPassword(value = newHex32BytesFrom(bytes = byteArray))
+
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+    //assert(password.value == bytes)
+    assert(password.value.bytes.contentEquals(byteArray))
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_resource_address.kts
+++ b/profile/tests/uniffi/bindings/test_resource_address.kts
@@ -1,0 +1,10 @@
+import radix.wallet.kit.*
+
+fun test() {
+	val bech32 = "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd"
+	val address = newResourceAddress(bech32 = bech32)
+	assert(address.address == bech32)
+	assert(address.networkId == NetworkId.MAINNET)
+}
+
+test()

--- a/profile/tests/uniffi/bindings/test_wallet.kts
+++ b/profile/tests/uniffi/bindings/test_wallet.kts
@@ -1,0 +1,143 @@
+import radix.wallet.kit.*
+import kotlin.random.Random
+
+fun test() {
+	println("🚀 Test Wallet in Kotlin start")
+
+	val storage = EphemeralKeystore() // Cannot use Object in kotlin script
+	assert(storage.isEmpty())
+
+	println("🔮 GENERATING NEW WALLET")
+	val wallet = Wallet.with(
+	    entropy = ByteArray(32) { 0xFF.toByte() },
+	    secureStorage = storage
+    )
+
+    assert(storage.contains(
+        value = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote"
+    ))
+    println("✨ SUCCESSFULLY GENERATED NEW WALLET ✅")
+
+    println("🔮 Creating first account on mainnet")
+    val initialNameOfFirstAccount = "Alice"
+    // Not created any account yet...
+    assert(!storage.contains(value = initialNameOfFirstAccount))
+    assert(wallet.profile().networks.size == 0)
+    var main0 = wallet.createAndSaveNewAccount(
+        networkId = NetworkId.MAINNET,
+        name = DisplayName.from(value = initialNameOfFirstAccount)
+    )
+    assert(main0.networkId == NetworkId.MAINNET)
+    assert(wallet.profile().networks.size == 1)
+    assert(wallet.profile().networks[0].accounts.size == 1)
+    assert(wallet.profile().networks[0].accounts[0].displayName.value == initialNameOfFirstAccount)
+    assert(storage.contains(value = initialNameOfFirstAccount))
+    print("✨ Successfully created first account ✅")
+
+    print("🔮 Update account using `update_account`")
+    var updatedNameOfFirstAccount = "Stella"
+    main0.displayName = DisplayName.from(value = updatedNameOfFirstAccount)
+    main0.appearanceId = AppearanceId.placeholderOther
+    val main0Updated = wallet.updateAccount(to = main0)
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+    //assert(main0Updated == main0)
+    assert(wallet.profile().networks[0].accounts[0].displayName.value == updatedNameOfFirstAccount)
+    assert(wallet.profile().networks[0].accounts[0].appearanceId == AppearanceId.placeholderOther)
+    assert(storage.contains(value = updatedNameOfFirstAccount))
+    print("✨ Successfully updated first account using `update_account` ✅")
+
+    print("🔮 Renaming account using changeNameOfAccount")
+    updatedNameOfFirstAccount = "Satoshi"
+    main0 = wallet.changeNameOfAccount(
+        address = main0.address,
+        to = DisplayName.from(value = updatedNameOfFirstAccount)
+    )
+    assert(wallet.profile().networks[0].accounts[0].displayName.value == updatedNameOfFirstAccount)
+    assert(storage.contains(value = updatedNameOfFirstAccount))
+    print("✨ Successfully renamed first account using changeNameOfAccount ✅")
+
+    print("🔮 Creating second mainnet account")
+    val main1 = wallet.createAndSaveNewAccount(
+        networkId = NetworkId.MAINNET,
+        name = DisplayName.from(value = "Bob")
+    )
+    assert(main0.address != main1.address)
+    assert(main0.networkId == main1.networkId)
+    assert(wallet.profile().networks.size == 1)
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+    //assert(wallet.profile().networks[0].accounts == listOf(main0, main1))
+
+    print("🔮 Creating first testnet account")
+    val testnetAccountName = "Hello Radix Account!"
+    val test0 = wallet.createAndSaveNewAccount(
+        networkId = NetworkId.STOKENET,
+        name = DisplayName.from(value = testnetAccountName)
+    )
+    assert(wallet.profile().networks.size == 2)
+    // TODO will change these when HexCoded32Bytes is represented with a list of bytes
+    //assert(wallet.profile().networks[1].accounts == listOf(test0))
+    assert(wallet.profile().networks[1].accounts[0].displayName.value == testnetAccountName)
+    assert(wallet.profile().networks[1].accounts[0].networkId == NetworkId.STOKENET)
+    assert(storage.contains(value = testnetAccountName))
+	println("✨ Successfully created first testnet account ✅")
+
+    println("✅ Test Wallet in Kotlin completed ")
+}
+
+test()
+
+// Helpers
+val Profile.Companion.placeholder: Profile
+    get() = newProfilePlaceholder()
+
+fun DisplayName.Companion.from(value: String): DisplayName {
+    return newDisplayName(name = value)
+}
+
+val AppearanceId.Companion.placeholder: AppearanceId
+    get() = newAppearanceIdPlaceholder()
+
+val AppearanceId.Companion.placeholderOther: AppearanceId
+    get() = newAppearanceIdPlaceholderOther()
+
+val Wallet.Companion.defaultPhoneName: String
+    get() = "Android Phone"
+
+fun Wallet.Companion.with(
+    entropy: ByteArray = ByteArray(32).apply { Random.nextBytes(this) },
+    phoneName: String = Wallet.Companion.defaultPhoneName,
+    secureStorage: SecureStorage
+): Wallet {
+    return Wallet.byCreatingNewProfileAndSecretsWithEntropy(
+        entropy = entropy,
+        walletClientModel = WalletClientModel.ANDROID,
+        walletClientName = phoneName,
+        secureStorage = secureStorage
+    )
+}
+
+val SecureStorageKey.identifier: String
+    get() = secureStorageKeyIdentifier(this)
+
+class EphemeralKeystore: SecureStorage {
+    private val storage: MutableMap<String, ByteArray> = mutableMapOf()
+
+    override fun loadData(key: SecureStorageKey): ByteArray? = storage[key.identifier]
+
+    override fun saveData(key: SecureStorageKey, data: ByteArray) {
+        storage[key.identifier] = data
+    }
+
+    override fun deleteDataForKey(key: SecureStorageKey) {
+        storage.remove(key = key.identifier)
+    }
+
+    fun isEmpty() = storage.isEmpty()
+
+    fun contains(value: String): Boolean {
+        return storage.any { entry ->
+            entry.value.decodeToString().contains(value)
+        }
+    }
+
+}

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -35,7 +35,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_profile.swift"
+        "tests/uniffi/bindings/test_profile.swift",
+        "tests/uniffi/bindings/test_profile.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -12,6 +12,7 @@ mod tests {
 
     uniffi::build_foreign_language_testcases!(
         "tests/uniffi/bindings/test_resource_address.swift",
+        "tests/uniffi/bindings/test_resource_address.kts",
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -19,7 +19,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_header.swift"
+        "tests/uniffi/bindings/test_header.swift",
+        "tests/uniffi/bindings/test_header.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -22,7 +22,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_factor_sources.swift"
+        "tests/uniffi/bindings/test_factor_sources.swift",
+        "tests/uniffi/bindings/test_factor_sources.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -6,6 +6,7 @@ mod tests {
 
     uniffi::build_foreign_language_testcases!(
         "tests/uniffi/bindings/test_account_address.swift",
+        "tests/uniffi/bindings/test_account_address.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -40,7 +40,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_radix_connect_password.swift"
+        "tests/uniffi/bindings/test_radix_connect_password.swift",
+        "tests/uniffi/bindings/test_radix_connect_password.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -2,6 +2,7 @@
 mod tests {
     uniffi::build_foreign_language_testcases!(
         "tests/uniffi/bindings/test_keys.swift",
+        "tests/uniffi/bindings/test_keys.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -51,6 +51,7 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_wallet.swift"
+        "tests/uniffi/bindings/test_wallet.swift",
+        "tests/uniffi/bindings/test_wallet.kts"
     );
 }

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -42,7 +42,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_hex32_bytes.swift"
+        "tests/uniffi/bindings/test_hex32_bytes.swift",
+        "tests/uniffi/bindings/test_hex32_bytes.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -26,7 +26,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_app_preferences.swift"
+        "tests/uniffi/bindings/test_app_preferences.swift",
+        "tests/uniffi/bindings/test_app_preferences.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/tests/uniffi/main.rs
+++ b/profile/tests/uniffi/main.rs
@@ -14,7 +14,8 @@ mod tests {
     );
 
     uniffi::build_foreign_language_testcases!(
-        "tests/uniffi/bindings/test_gateways.swift"
+        "tests/uniffi/bindings/test_gateways.swift",
+        "tests/uniffi/bindings/test_gateways.kts"
     );
 
     uniffi::build_foreign_language_testcases!(

--- a/profile/uniffi.toml
+++ b/profile/uniffi.toml
@@ -4,6 +4,9 @@
 # mutated the stored properties on account.
 generate_immutable_records = false
 
+[bindings.kotlin]
+package_name = "radix.wallet.kit"
+
 [bindings.swift.custom_types.Uuid]
 # Name of the type in the Swift code
 type_name = "UUID"

--- a/profile/uniffi.toml
+++ b/profile/uniffi.toml
@@ -44,7 +44,10 @@ from_custom = "String(describing: {})"
 # Name of the type in the Kotlin code
 type_name = "URL"
 # Classes that need to be imported
-imports = ["java.net.URI", "java.net.URL"]
+imports = [
+    "java.net.URI",
+    "java.net.URL"
+]
 # Functions to convert between strings and URLs
 into_custom = "URI({}).toURL()"
 from_custom = "{}.toString()"
@@ -70,7 +73,10 @@ from_custom = "{let df = DateFormatter();df.dateFormat = \"yyyy-MM-dd'T'HH:mm:ss
 
 [bindings.kotlin.custom_types.Timestamp]
 type_name = "OffsetDateTime"
-imports = ["java.time"]
+imports = [
+    "java.time.OffsetDateTime",
+    "java.time.format.DateTimeFormatter"
+]
 into_custom = "OffsetDateTime.parse({}, DateTimeFormatter.ISO_DATE_TIME)"
 from_custom = "{}.format(DateTimeFormatter.ISO_DATE_TIME)"
 


### PR DESCRIPTION
Tests written in Kotlin script that validate the usage of this library in the Kotlin world. 

Some changes were needed in order to be able to compile the library in kotlin:
1. Renaming some enums to resolve such errors
    ```
    .../radix_wallet_kit.kt:4874:17: error: type mismatch: inferred type is uniffi.radix_wallet_kit.AccountPath but 
    uniffi.radix_wallet_kit.Cap26Path.AccountPath was expected
                FfiConverterTypeAccountPath.read(buf),
    ```
     `CAP26Path` enum values to:
        * `GetID`
        * `Account`
        * `Identity` 
        
     `DepositorAddress` enum values to:
         * `Resource`
         * `NFGlobalID`
2. Uniffi toml configuration:
    * Used the correct imports for `java.time.*`
    * Renamed the `package_name = "radix.wallet.kit"`
3. See the updated Readme regarding what it needs to build and run the tests
    * In order for KTS scripts to run the user needs to install Kotlin with
      ```
      brew install kotlin
      ```
    * Download the required JNA library
      ```
      wget https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar
      ```
    * And include it in the classpath when running the tests
      ```
      JAVA_OPTS="-Xmx8g" CLASSPATH="path-to-jna/jna-5.13.0.jar" cargo nextest run --package profile --test uniffi && cargo nextest run
      ```
---

## Pending
* Some assertions are commented out. They have to do with equality check that will be resolved by this [PR](https://github.com/Sajjon/RadixWalletKit/pull/31). All such assertions have a TODO comment
`// TODO will change these when HexCoded32Bytes is represented with a list of bytes`
* URL, UDID, OffsetDateTime classes are not yet verified through tests. This will come in a later PR.
      